### PR TITLE
Method to give extra permissions

### DIFF
--- a/ReadWriteMemory/__init__.py
+++ b/ReadWriteMemory/__init__.py
@@ -151,6 +151,28 @@ class ReadWriteMemory:
     def __init__(self):
         self.process = Process()
 
+    @staticmethod
+    def set_privileges():
+        import win32con
+        import win32api
+        import win32security
+        import ntsecuritycon
+        from ntsecuritycon import TokenPrivileges
+
+        remote_server = None
+        th = win32security.OpenProcessToken(win32api.GetCurrentProcess(), win32con.TOKEN_ADJUST_PRIVILEGES | win32con.TOKEN_QUERY)
+        privs = win32security.GetTokenInformation(th, TokenPrivileges)
+        newprivs = []
+        for privtuple in privs:
+            if privtuple[0] == win32security.LookupPrivilegeValue(remote_server, "SeBackupPrivilege") or privtuple[0] == win32security.LookupPrivilegeValue(remote_server, "SeDebugPrivilege") or privtuple[0] == win32security.LookupPrivilegeValue(remote_server, "SeSecurityPrivilege"):
+                #print("Added privilege " + str(privtuple[0]))
+                newprivs.append((privtuple[0], 2))
+            else:
+                newprivs.append((privtuple[0], privtuple[1]))       
+        # Adjust privs
+        privs = tuple(newprivs)
+        win32security.AdjustTokenPrivileges(th, False , privs)
+
     def get_process_by_name(self, process_name: [str, bytes]) -> "Process":
         """
         :description: Get the process by the process executabe\'s name and return a Process object.


### PR DESCRIPTION
This new method allows us to add additional administrator permissions to allow us to open some processes protected by administrator permissions.

Example:
```py
from ReadWriteMemory import ReadWriteMemory

rwm = ReadWriteMemory()
rwm.set_privileges()
process = rwm.get_process_by_name("Growtopia.exe")
print(process)
```

It is worth mentioning that in order to use `set_privileges` you must run the interpreter in admin mode in order to get the permissions.

This requires some extra modules:
```py
# win32con
# win32api
# win32security
# ntsecuritycon
```

Credits for the repository: [WHP](https://github.com/51x/WHP)
this is a copy paste of this file: https://github.com/51x/WHP/blob/c42a0ab7a706dfe4bfaf8f30948a7c8e393fee10/windows-privesc-check.py#L1632