### PR TITLE
Add a new and simple method to get the base address

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ rwm = ReadWriteMemory()
 process = rwm.get_process_by_id(1337)
 ```
 
+### Get Base Address of the Process
+```py
+from ReadWriteMemory import ReadWriteMemory
+
+rwm = ReadWriteMemory()
+
+process = rwm.get_process_by_name('ac_client.exe')
+# Remember to open the process first in order to get the base address of the process
+process.open()
+base_address = process.get_base_address()
+```
+
 ### Get the list of running processes ID's from the current system
 ```python
 from ReadWriteMemory import ReadWriteMemory

--- a/ReadWriteMemory/__init__.py
+++ b/ReadWriteMemory/__init__.py
@@ -104,6 +104,13 @@ class Process(object):
         ctypes.windll.psapi.EnumProcessModules(self.handle, modules, ctypes.sizeof(modules), None)
         return [x for x in tuple(modules) if x != None]
 
+    def get_base_address(self):
+        """
+        Get the base address of the process.
+        :return: The base address of the process.
+        """
+        return self.get_modules()[0]
+
     def thread(self, address: int):
         """
         Create a remote thread to the address.


### PR DESCRIPTION
After the merged PR #21 We can now obtain the base address of the process very easily: `get_modules()[0]`
but to make it intuitive and easy to understand for everyone it is better to have a method for it: `get_base_address()`